### PR TITLE
Merging utilities

### DIFF
--- a/fourier.py
+++ b/fourier.py
@@ -49,7 +49,7 @@ def newFreq(f,p,nf):
     """
     Interpolate a power spectrum onto a new frequency grid.
     """
-    return griddata(f,p,nf,method=metehod)
+    return griddata(f,p,nf,method=method)
 
 def freqgrid(d,dx=1.):
     """Return a frequency grid to match FFT components

--- a/imaging/analysis.py
+++ b/imaging/analysis.py
@@ -59,6 +59,7 @@ class pointGetter:
     When done, the user can press the space key.
     """
     def __init__(self,img,log=False):
+        ion()
         self.fig = figure()
         self.x = zeros(0)
         self.y = zeros(0)

--- a/imaging/man.py
+++ b/imaging/man.py
@@ -75,12 +75,12 @@ def padNaN(img,n=1,axis=0):
         img = np.concatenate((img,ins),axis=axis)
     return img
 
-def padRect(img):
-    """Pads an image with an outer NaN rectangle"""
-    img = padNaN(img,n=1,axis=0)
-    img = padNaN(img,n=-1,axis=0)
-    img = padNaN(img,n=1,axis=1)
-    img = padNaN(img,n=-1,axis=1)
+def padRect(img,nan_num = 1):
+    """Pads an image with an outer NaN rectangle of width nan_num"""
+    img = padNaN(img,n=nan_num,axis=0)
+    img = padNaN(img,n=-nan_num,axis=0)
+    img = padNaN(img,n=nan_num,axis=1)
+    img = padNaN(img,n=-nan_num,axis=1)
     return img
 
 def tipTiltPiston(img,piston,tip,tilt,tx=None,ty=None):

--- a/imaging/man.py
+++ b/imaging/man.py
@@ -83,6 +83,11 @@ def padRect(img,nan_num = 1):
     img = padNaN(img,n=-nan_num,axis=1)
     return img
 
+def borderFill(img,n = 1,fill_value = np.NaN):
+    img[:n],img[-n:] = fill_value,fill_value
+    img[:,:n],img[:,-n:] = fill_value,fill_value
+    return img
+
 def tipTiltPiston(img,piston,tip,tilt,tx=None,ty=None):
     """This function adds a constant and
     tip and tilt to an array
@@ -240,6 +245,8 @@ def removeDS9Regions(img,filename):
     for l in lines:
         t = l.split('(')[0]
         n = np.array(l.split('(')[1].split(','))
+        # Note: this can throw an error based on Mac vs. Windows -- if there's a carriage return
+        # plus a new line, the second value should be -3.
         n[-1] = n[-1][:-2]
         n = n.astype('float')
         if t == 'circle':

--- a/metrology.py
+++ b/metrology.py
@@ -212,8 +212,32 @@ def readCylWFS(fn,rotate=np.linspace(.75,1.5,50),interp=None):
     #Remove cylindrical misalignment terms
     d = d - fit.fitCylMisalign(d)[0]
     
-    # Flip up/down based on CGH orientation and negate to make bump positive.
-    d = -np.flipud(d)
+    # Negate to make bump positive.
+    d = -d
+    
+    #Interpolate over NaNs
+    if interp is not None:
+        d = man.nearestNaN(d,method=interp)
+
+    return d
+
+def readFlatWFS(fn,interp=None):
+    """
+    Load in data from WFS measurement of flat mirror.
+    Assumes that data was processed using processHAS, and loaded into
+    a .fits file.
+    Scale to microns, strip NaNs.
+    If rotate is set to an array of angles, the rotation angle
+    which minimizes the number of NaNs in the image after
+    stripping perimeter nans is selected.
+    Distortion is bump positive looking at concave surface.
+    Imshow will present distortion in proper orientation as if
+    viewing the concave surface.
+    """
+    #Remove NaNs and rescale
+    d = pyfits.getdata(fn)
+    d = man.stripnans(d)
+    d = -d
     
     #Interpolate over NaNs
     if interp is not None:

--- a/metrology.py
+++ b/metrology.py
@@ -212,8 +212,9 @@ def readCylWFS(fn,rotate=np.linspace(.75,1.5,50),interp=None):
     #Remove cylindrical misalignment terms
     d = d - fit.fitCylMisalign(d)[0]
     
-    # Negate to make bump positive.
+    # Negate to make bump positive and rotate to be consistent with looking at the part beamside.
     d = -d
+    d = np.rot90(d,k = 2)
     
     #Interpolate over NaNs
     if interp is not None:
@@ -337,3 +338,6 @@ def convertzygo(filename):
 
     np.savetxt(filename.split('.')[0]+'.txt',phase,header='Lat scale: '+\
             str(latscale)+'\n'+'Units: meters')
+
+def make_extent(data,dx):
+    return [-float(np.shape(data)[1])/2*dx,float(np.shape(data)[1])/2*dx,-float(np.shape(data)[0])/2*dx,float(np.shape(data)[0])/2*dx]

--- a/transformations.py
+++ b/transformations.py
@@ -1865,42 +1865,42 @@ def is_same_transform(matrix0, matrix1):
     return numpy.allclose(matrix0, matrix1)
 
 
-def _import_module(name, package=None, warn=True, prefix='_py_', ignore='_'):
-    """Try import all public attributes from module into global namespace.
-
-    Existing attributes with name clashes are renamed with prefix.
-    Attributes starting with underscore are ignored by default.
-
-    Return True on successful import.
-
-    """
-    import warnings
-    from importlib import import_module
-    try:
-        if not package:
-            module = import_module(name)
-        else:
-            module = import_module('.' + name, package=package)
-    except ImportError:
-        if warn:
-            warnings.warn("failed to import module %s" % name)
-    else:
-        for attr in dir(module):
-            if ignore and attr.startswith(ignore):
-                continue
-            if prefix:
-                if attr in globals():
-                    globals()[prefix + attr] = globals()[attr]
-                elif warn:
-                    warnings.warn("no Python implementation of " + attr)
-            globals()[attr] = getattr(module, attr)
-        return True
-
-
-_import_module('_transformations')
-
-if __name__ == "__main__":
-    import doctest
-    import random  # used in doctests
-    numpy.set_printoptions(suppress=True, precision=5)
-    doctest.testmod()
+#def _import_module(name, package=None, warn=True, prefix='_py_', ignore='_'):
+#    """Try import all public attributes from module into global namespace.
+#
+#    Existing attributes with name clashes are renamed with prefix.
+#    Attributes starting with underscore are ignored by default.
+#
+#    Return True on successful import.
+#
+#    """
+#    import warnings
+#    from importlib import import_module
+#    try:
+#        if not package:
+#            module = import_module(name)
+#        else:
+#            module = import_module('.' + name, package=package)
+#    except ImportError:
+#        if warn:
+#            warnings.warn("failed to import module %s" % name)
+#    else:
+#        for attr in dir(module):
+#            if ignore and attr.startswith(ignore):
+#                continue
+#            if prefix:
+#                if attr in globals():
+#                    globals()[prefix + attr] = globals()[attr]
+#                elif warn:
+#                    warnings.warn("no Python implementation of " + attr)
+#            globals()[attr] = getattr(module, attr)
+#        return True
+#
+#
+#_import_module('_transformations')
+#
+#if __name__ == "__main__":
+#    import doctest
+#    import random  # used in doctests
+#    numpy.set_printoptions(suppress=True, precision=5)
+#    doctest.testmod()


### PR DESCRIPTION
borderFill is padNaN in all axes by N pixels
modifications to stitch allow for fiducial alignment when the magnifications of the instruments are different
make_extent makes plt.imshow arguments easier for physical dimensions (e.g. plt.imshow(img, extent = met.make_extent(img,dx))

Not sure what's going on with _import_module in transformations -- is this you?